### PR TITLE
Update homepage wording from startups to founders

### DIFF
--- a/welcome.mdx
+++ b/welcome.mdx
@@ -5,7 +5,7 @@ mode: "wide"
 icon: "hand-wave"
 ---
 
-This guide is a collection of advice and best practices to help startups navigate taxes, accounting, and finances with confidence and make smarter decisions.
+This guide is a collection of advice and best practices to help founders navigate taxes, accounting, and finances with confidence and make smarter decisions.
 
 <AccordionGroup>
   <Accordion title="Purpose">


### PR DESCRIPTION
Update documentation wording from 'startups' to 'founders' to align with Linear issue EPD-699.

---
Linear Issue: [EPD-699](https://linear.app/finta-app/issue/EPD-699/change-wording-in-docs)

<a href="https://cursor.com/background-agent?bcId=bc-e1a982e8-807a-4c5e-858a-62f8f6060ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1a982e8-807a-4c5e-858a-62f8f6060ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

